### PR TITLE
return entire array, not just latest $state in getLightState()

### DIFF
--- a/hue.php
+++ b/hue.php
@@ -43,7 +43,7 @@ function getLightState($lightid = false) {
 		$result[$id] = $state;
 
 	}
-	return $state;
+	return $result;
 }
 
 // Returns an array of the light numbers in the system


### PR DESCRIPTION
getLightState wasn't returning the entire $result array. It was just returning the latest iteration of $state
